### PR TITLE
feat: Projects CRUD API実装

### DIFF
--- a/backend/app/controllers/api/v1/projects_controller.rb
+++ b/backend/app/controllers/api/v1/projects_controller.rb
@@ -1,0 +1,57 @@
+module Api
+  module V1
+    class ProjectsController < ApplicationController
+      before_action :authenticate_user!
+      before_action :set_project, only: %i[show update destroy]
+
+      # GET /api/v1/projects
+      def index
+        @projects = current_user.projects.order(created_at: :desc)
+        render json: @projects
+      end
+
+      # GET /api/v1/projects/:id
+      def show
+        render json: @project
+      end
+
+      # POST /api/v1/projects
+      def create
+        @project = current_user.projects.build(project_params)
+
+        if @project.save
+          render json: @project, status: :created
+        else
+          render json: { errors: @project.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH/PUT /api/v1/projects/:id
+      def update
+        if @project.update(project_params)
+          render json: @project
+        else
+          render json: { errors: @project.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/projects/:id
+      def destroy
+        @project.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_project
+        @project = current_user.projects.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "プロジェクトが見つかりません" }, status: :not_found
+      end
+
+      def project_params
+        params.require(:project).permit(:name, :description, :color)
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -1,0 +1,64 @@
+module Api
+  module V1
+    class TasksController < ApplicationController
+      before_action :authenticate_user!
+      before_action :set_project, only: [ :index, :create ]
+      before_action :set_task, only: %i[show update destroy]
+
+      # GET /api/v1/projects/:project_id/tasks
+      def index
+        @tasks = @project.tasks.order(created_at: :desc)
+        render json: @tasks
+      end
+
+      # GET /api/v1/tasks/:id
+      def show
+        render json: @task
+      end
+
+      # POST /api/v1/projects/:project_id/tasks
+      def create
+        @task = @project.tasks.build(task_params)
+
+        if @task.save
+          render json: @task, status: :created
+        else
+          render json: { errors: @task.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH/PUT /api/v1/tasks/:id
+      def update
+        if @task.update(task_params)
+          render json: @task
+        else
+          render json: { errors: @task.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/tasks/:id
+      def destroy
+        @task.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_project
+        @project = current_user.projects.find(params[:project_id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "プロジェクトが見つかりません" }, status: :not_found
+      end
+
+      def set_task
+        @task = Task.joins(:project).where(projects: { user_id: current_user.id }).find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "タスクが見つかりません" }, status: :not_found
+      end
+
+      def task_params
+        params.require(:task).permit(:title, :description, :status, :estimated_hours)
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/time_entries_controller.rb
+++ b/backend/app/controllers/api/v1/time_entries_controller.rb
@@ -1,0 +1,70 @@
+module Api
+  module V1
+    class TimeEntriesController < ApplicationController
+      before_action :authenticate_user!
+      before_action :set_time_entry, only: %i[show update destroy]
+
+      # GET /api/v1/time_entries
+      def index
+        @time_entries = current_user.time_entries
+                                    .includes(:task, task: :project)
+                                    .order(start_time: :desc)
+
+        # フィルタリング
+        @time_entries = @time_entries.where(task_id: params[:task_id]) if params[:task_id].present?
+        if params[:project_id].present?
+          @time_entries = @time_entries.joins(task: :project).where(tasks: { project_id: params[:project_id] })
+        end
+        if params[:start_date].present?
+          @time_entries = @time_entries.where("start_time >= ?", params[:start_date])
+        end
+        @time_entries = @time_entries.where("start_time <= ?", params[:end_date]) if params[:end_date].present?
+
+        render json: @time_entries, include: { task: { include: :project } }
+      end
+
+      # GET /api/v1/time_entries/:id
+      def show
+        render json: @time_entry, include: { task: { include: :project } }
+      end
+
+      # POST /api/v1/time_entries
+      def create
+        @time_entry = current_user.time_entries.build(time_entry_params)
+
+        if @time_entry.save
+          render json: @time_entry, status: :created, include: { task: { include: :project } }
+        else
+          render json: { errors: @time_entry.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH/PUT /api/v1/time_entries/:id
+      def update
+        if @time_entry.update(time_entry_params)
+          render json: @time_entry, include: { task: { include: :project } }
+        else
+          render json: { errors: @time_entry.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/time_entries/:id
+      def destroy
+        @time_entry.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_time_entry
+        @time_entry = current_user.time_entries.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "時間記録が見つかりません" }, status: :not_found
+      end
+
+      def time_entry_params
+        params.require(:time_entry).permit(:task_id, :start_time, :end_time, :description)
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -18,6 +18,13 @@ Rails.application.routes.draw do
         post "refresh", to: "authentication#refresh"
         get "me", to: "authentication#me"
       end
+
+      # リソース
+      resources :projects do
+        resources :tasks, only: [ :index, :create ]
+      end
+      resources :tasks, only: [ :show, :update, :destroy ]
+      resources :time_entries
     end
   end
 end

--- a/backend/db/migrate/20260120140545_add_color_to_projects.rb
+++ b/backend/db/migrate/20260120140545_add_color_to_projects.rb
@@ -1,0 +1,5 @@
+class AddColorToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :color, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_20_124700) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_20_140545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "projects", force: :cascade do |t|
+    t.string "color"
     t.datetime "created_at", null: false
     t.text "description"
     t.string "name", null: false

--- a/backend/lib/json_web_token.rb
+++ b/backend/lib/json_web_token.rb
@@ -3,8 +3,8 @@
 # JWTトークンのエンコード・デコードを行うモジュール
 module JsonWebToken
   # 秘密鍵（環境変数から取得、なければRailsのsecret_key_baseを使用）
-  SECRET_KEY = ENV.fetch('JWT_SECRET_KEY') { Rails.application.credentials.secret_key_base }
-  
+  SECRET_KEY = ENV.fetch("JWT_SECRET_KEY") { Rails.application.credentials.secret_key_base }
+
   # トークンの有効期限（24時間）
   EXPIRATION_TIME = 24.hours.from_now.to_i
 
@@ -14,7 +14,7 @@ module JsonWebToken
   # @return [String] エンコードされたJWTトークン
   def self.encode(payload)
     payload[:exp] = EXPIRATION_TIME
-    JWT.encode(payload, SECRET_KEY, 'HS256')
+    JWT.encode(payload, SECRET_KEY, "HS256")
   end
 
   # JWTトークンをデコード
@@ -22,7 +22,7 @@ module JsonWebToken
   # @param token [String] デコードするJWTトークン
   # @return [HashWithIndifferentAccess, nil] デコードされたデータ、エラー時はnil
   def self.decode(token)
-    decoded = JWT.decode(token, SECRET_KEY, true, algorithm: 'HS256')
+    decoded = JWT.decode(token, SECRET_KEY, true, algorithm: "HS256")
     HashWithIndifferentAccess.new(decoded[0])
   rescue JWT::DecodeError => e
     Rails.logger.error("JWT Decode Error: #{e.message}")

--- a/backend/spec/factories/projects.rb
+++ b/backend/spec/factories/projects.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :project do
+    association :user
+    name { "プロジェクト#{rand(1000)}" }
+    description { "プロジェクトの説明" }
+    color { "##{SecureRandom.hex(3)}" }
+  end
+end

--- a/backend/spec/factories/tasks.rb
+++ b/backend/spec/factories/tasks.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :task do
+    association :project
+    title { "タスク#{rand(1000)}" }
+    description { "タスクの説明" }
+    status { "todo" }
+    estimated_hours { 5.0 }
+  end
+end

--- a/backend/spec/factories/time_entries.rb
+++ b/backend/spec/factories/time_entries.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :time_entry do
+    association :user
+    association :task
+    start_time { 2.hours.ago }
+    end_time { 1.hour.ago }
+    description { "作業内容の説明" }
+  end
+end

--- a/backend/spec/requests/api/v1/projects_spec.rb
+++ b/backend/spec/requests/api/v1/projects_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Projects', type: :request do
+  before do
+    host! 'localhost'
+  end
+
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:token) { JsonWebToken.encode(user_id: user.id) }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+
+  describe 'GET /api/v1/projects' do
+    let!(:user_projects) { create_list(:project, 3, user: user) }
+    let!(:other_projects) { create_list(:project, 2, user: other_user) }
+
+    it 'returns user projects only' do
+      get '/api/v1/projects', headers: headers
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json.length).to eq(3)
+      expect(json.map { |p| p['user_id'] }.uniq).to eq([ user.id ])
+    end
+
+    it 'requires authentication' do
+      get '/api/v1/projects'
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'GET /api/v1/projects/:id' do
+    let(:project) { create(:project, user: user) }
+
+    it 'returns the project' do
+      get "/api/v1/projects/#{project.id}", headers: headers
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json['id']).to eq(project.id)
+      expect(json['name']).to eq(project.name)
+    end
+
+    it 'returns 404 for other user project' do
+      other_project = create(:project, user: other_user)
+      get "/api/v1/projects/#{other_project.id}", headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'POST /api/v1/projects' do
+    let(:valid_attributes) do
+      {
+        project: {
+          name: 'New Project',
+          description: 'Project description',
+          color: '#FF5733'
+        }
+      }
+    end
+
+    it 'creates a new project' do
+      expect {
+        post '/api/v1/projects', params: valid_attributes, headers: headers, as: :json
+      }.to change(Project, :count).by(1)
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json['name']).to eq('New Project')
+      expect(json['user_id']).to eq(user.id)
+    end
+
+    it 'returns errors for invalid data' do
+      post '/api/v1/projects', params: { project: { name: '' } }, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json['errors']).to be_present
+    end
+  end
+
+  describe 'PATCH /api/v1/projects/:id' do
+    let(:project) { create(:project, user: user) }
+
+    it 'updates the project' do
+      patch "/api/v1/projects/#{project.id}",
+            params: { project: { name: 'Updated Name' } },
+            headers: headers,
+            as: :json
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json['name']).to eq('Updated Name')
+    end
+
+    it 'returns 404 for other user project' do
+      other_project = create(:project, user: other_user)
+      patch "/api/v1/projects/#{other_project.id}",
+            params: { project: { name: 'Hacked' } },
+            headers: headers,
+            as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'DELETE /api/v1/projects/:id' do
+    let!(:project) { create(:project, user: user) }
+
+    it 'deletes the project' do
+      expect {
+        delete "/api/v1/projects/#{project.id}", headers: headers
+      }.to change(Project, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'returns 404 for other user project' do
+      other_project = create(:project, user: other_user)
+      expect {
+        delete "/api/v1/projects/#{other_project.id}", headers: headers
+      }.not_to change(Project, :count)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Projects、Tasks、TimeEntriesのCRUD APIを実装しました。

## 実装内容

### コントローラー
- **Projectsコントローラー** ([`app/controllers/api/v1/projects_controller.rb`](../backend/app/controllers/api/v1/projects_controller.rb))
  - `GET /api/v1/projects` - プロジェクト一覧取得
  - `GET /api/v1/projects/:id` - プロジェクト詳細取得
  - `POST /api/v1/projects` - プロジェクト作成
  - `PATCH/PUT /api/v1/projects/:id` - プロジェクト更新
  - `DELETE /api/v1/projects/:id` - プロジェクト削除

- **Tasksコントローラー** ([`app/controllers/api/v1/tasks_controller.rb`](../backend/app/controllers/api/v1/tasks_controller.rb))
  - `GET /api/v1/projects/:project_id/tasks` - タスク一覧取得
  - `GET /api/v1/tasks/:id` - タスク詳細取得
  - `POST /api/v1/projects/:project_id/tasks` - タスク作成
  - `PATCH/PUT /api/v1/tasks/:id` - タスク更新
  - `DELETE /api/v1/tasks/:id` - タスク削除

- **TimeEntriesコントローラー** ([`app/controllers/api/v1/time_entries_controller.rb`](../backend/app/controllers/api/v1/time_entries_controller.rb))
  - `GET /api/v1/time_entries` - 時間記録一覧取得（フィルタリング機能付き）
  - `GET /api/v1/time_entries/:id` - 時間記録詳細取得
  - `POST /api/v1/time_entries` - 時間記録作成
  - `PATCH/PUT /api/v1/time_entries/:id` - 時間記録更新
  - `DELETE /api/v1/time_entries/:id` - 時間記録削除

### セキュリティ
- JWT認証必須（`before_action :authenticate_user!`）
- ユーザーは自分のデータのみアクセス可能
- 他のユーザーのデータへのアクセスは404エラー

### テスト
- **Projectsリクエストスペック**: 10 examples, 0 failures ✅
- **全テスト**: 32 examples, 0 failures ✅
- **カバレッジ**: 43.51%

### その他
- FactoryBot設定（projects, tasks, time_entries）
- RESTfulルーティング設定
- colorカラムをProjectsテーブルに追加
- RuboCop自動修正実行

## 技術的な課題と解決
- **メソッド名の統一**: `authorize_request` → `authenticate_user!`に統一
- **colorカラムの追加**: マイグレーションを作成して対応

## 動作確認
```bash
# 全テスト実行
docker-compose run --rm backend bundle exec rspec

# RuboCop実行
docker-compose run --rm backend bundle exec rubocop
```

## 関連Issue
Closes #11